### PR TITLE
Adjust Facebook floating button z-index

### DIFF
--- a/TESTSECRETO/index.html
+++ b/TESTSECRETO/index.html
@@ -135,7 +135,7 @@
             position: fixed;
             bottom: 20px;
             right: 80px;
-            z-index: 1050;
+            z-index: 1040;
             cursor: pointer;
             border-radius: 50%;
             overflow: hidden;
@@ -1784,8 +1784,7 @@
             </div>
         </div>
         <!-- Ícono flotante de Facebook -->
-        <a href="#" data-bs-toggle="modal" data-bs-target="#facebookModal" class="facebook-float"
-            style="position: fixed; bottom: 80px; right: 20px; z-index: 1055; box-shadow: 0 2px 10px rgb(29, 112, 255);">
+        <a href="#" data-bs-toggle="modal" data-bs-target="#facebookModal" class="facebook-float">
             <img src="https://cdn-icons-png.flaticon.com/512/733/733547.png" alt="Facebook" width="50" height="50">
         </a>
 

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
             position: fixed;
             bottom: 20px;
             right: 80px;
-            z-index: 1050;
+            z-index: 1040;
             cursor: pointer;
             border-radius: 50%;
             overflow: hidden;
@@ -2036,8 +2036,7 @@
             </div>
         </div>
         <!-- Ícono flotante de Facebook -->
-        <a href="#" data-bs-toggle="modal" data-bs-target="#facebookModal" class="facebook-float"
-            style="position: fixed; bottom: 80px; right: 20px; z-index: 1055; box-shadow: 0 2px 10px rgb(29, 112, 255);">
+        <a href="#" data-bs-toggle="modal" data-bs-target="#facebookModal" class="facebook-float">
             <img src="https://cdn-icons-png.flaticon.com/512/733/733547.png" alt="Facebook" width="50" height="50">
         </a>
 


### PR DESCRIPTION
## Summary
- Remove inline styles from the Facebook floating link and style it via CSS
- Lower `.facebook-float` z-index to 1040 so Bootstrap modals overlay it
- Mirror these changes in the test HTML copy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895bdd5d3808322829eefa156919d1b